### PR TITLE
fix: trying to fix npm rejection by new version release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twsh",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "While developing, you can post (and read) tweet.",
   "bin": {
     "twsh": "./lib/routes/index.js"

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,7 +7,7 @@ import changeUser from '../app/change-user';
 
 const { argv } = process;
 
-program.version('1.0.0', '-v, --version');
+program.version('1.0.1', '-v, --version');
 
 program
   .command('change_user')


### PR DESCRIPTION
I think that the reason why I am rejected publishing version 1.0.0 is that I have released the same version before so I am trying to avoid rejecting by releasing new version. 